### PR TITLE
Add test for `mask` method

### DIFF
--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -29,3 +29,7 @@ class TestCnpj(unittest.TestCase):
         # validate
         for cnpj in self.cnpj.generate_list(10000):
             self.assertTrue(self.cnpj.validate(cnpj))
+
+    def test_mask(self):
+        """Verifica que o método `mask` retorna o valor correto"""
+        self.assertEquals('34.557.444/0001-44', self.cnpj.mask('34557444000144'))

--- a/tests/test_cns.py
+++ b/tests/test_cns.py
@@ -29,3 +29,7 @@ class TestCns(unittest.TestCase):
         # validate
         for cns in self.cns.generate_list(10000):
             self.assertTrue(self.cns.validate(cns))
+
+    def test_mask(self):
+        """Verifica que o método `mask` retorna o valor correto"""
+        self.assertEquals('150 3779 6667 0007', self.cns.mask('150377966670007'))

--- a/tests/test_cpf.py
+++ b/tests/test_cpf.py
@@ -51,3 +51,7 @@ class TestCpf(unittest.TestCase):
         self.cpf.repeated_digits = True
         for cpf in cpfs_repeated_digits:
             self.assertTrue(self.cpf.validate(cpf))
+
+    def test_mask(self):
+        """Verifica que o método `mask` retorna o valor correto"""
+        self.assertEquals('860.755.390-93', self.cpf.mask('86075539093'))


### PR DESCRIPTION
Adicionados os testes para o método `mask` das classes `CNS`, `CPF` e `CNPJ`.