### PR TITLE
Adiciona validador de tuplas de documentos

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -6,6 +6,7 @@ import tests.test_cns
 import tests.test_cnpj
 import tests.test_pis
 import tests.test_titulo_eleitor
+import tests.test_generic
 
 
 def suite():
@@ -18,6 +19,7 @@ def suite():
     test_suite.addTests(loader.loadTestsFromModule(tests.test_cnpj))
     test_suite.addTests(loader.loadTestsFromModule(tests.test_pis))
     test_suite.addTests(loader.loadTestsFromModule(tests.test_titulo_eleitor))
+    test_suite.addTests(loader.loadTestsFromModule(tests.test_generic))
 
     return test_suite
 

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,0 +1,47 @@
+import unittest
+import random
+
+import validate_docbr as docbr
+
+
+def get_random_number_str(length):
+    numbers = '0123456789'
+    return ''.join(random.choice(numbers) for i in range(length))
+
+
+class TestValidateDocs(unittest.TestCase):
+    """Testa a função validate_docs"""
+
+    def test_correct_argument(self):
+        """Testa a função quando os argumentos estão corretos"""
+        DocClasses = [
+            docbr.CPF,
+            docbr.CNH,
+            docbr.CNPJ,
+            docbr.CNS,
+            docbr.PIS,
+            docbr.TituloEleitoral,
+        ]
+
+        documents = []
+        right_answers = []
+
+        for DocClass in DocClasses:
+            # Documentos válidos
+            tuples = [(DocClass, doc) for doc in DocClass().generate_list(200)]
+            documents += tuples
+            right_answers += [True] * len(tuples)
+
+            # Documentos aleatórios
+            len_doc = len(DocClass().generate())
+            for i in range(200):
+                random_doc = get_random_number_str(len_doc)
+                documents += [(DocClass, random_doc)]
+                right_answers += [DocClass().validate(random_doc)]
+
+        self.assertEqual(docbr.validate_docs(documents), right_answers)
+
+    def test_incorrect_argument(self):
+        """Test a função quando os argumentos estão incorretos"""
+        with self.assertRaises(TypeError):
+            docbr.validate_docs([('cpf', docbr.CPF().generate())])

--- a/validate_docbr/__init__.py
+++ b/validate_docbr/__init__.py
@@ -5,3 +5,4 @@ from .CNH import CNH
 from .CNS import CNS
 from .PIS import PIS
 from .TituloEleitoral import TituloEleitoral
+from .generic import validate_docs

--- a/validate_docbr/generic.py
+++ b/validate_docbr/generic.py
@@ -1,0 +1,17 @@
+import inspect
+from .BaseDoc import BaseDoc
+
+
+def validate_docs(documents):
+    """Recebe uma lista de tuplas (ClasseDoc, NumeroDoc) e a valida"""
+    validations = []
+
+    for doc in documents:
+        if not inspect.isclass(doc[0]) or not issubclass(doc[0], BaseDoc):
+            raise TypeError(
+                "O primeiro índice da tupla deve ser uma classe de documento!"
+            )
+
+        validations.append(doc[0]().validate(doc[1]))
+
+    return validations


### PR DESCRIPTION
Resolve a issue #17.
Eu escolhi usar a própria classe como especificador de documento, assim a função `validate_docs` continuará funcionando mesmo com a adição de novos documentos.

Ex.
``` python
import validate_docbr as docbr

docs = [(docbr.CPF, '90396100457'), (docbr.CNPJ, '49910753848365')]
docbr.validate_docs(docs)
# Retorna -> [True, False]
```

Obs.: Os testes só rodarão sem erro quando a issue #30 for resolvida.