### PR TITLE
Corrigir type hint na função validate_docs()

### DIFF
--- a/validate_docbr/generic.py
+++ b/validate_docbr/generic.py
@@ -1,9 +1,9 @@
 import inspect
-from typing import List, Tuple
+from typing import List, Tuple, Type
 from .BaseDoc import BaseDoc
 
 
-def validate_docs(documents: List[Tuple[BaseDoc, str]] = list):
+def validate_docs(documents: List[Tuple[Type[BaseDoc], str]] = list):
     """Recebe uma lista de tuplas (classe, valor) e a valida"""
     validations = []
 


### PR DESCRIPTION
Olá. Obrigado por este módulo, ele tem me servido bem.

Esta atualização corrige a dica de tipo do argumento documents da função validate_docs(). Como a função espera uma classe nesta posição da tupla, e não uma instância, devemos envolver a classe com Type.