### PR TITLE
Adiciona checagem de CNPJ para saber se ele foi previamente formatado

### DIFF
--- a/tests/test_CNPJ.py
+++ b/tests/test_CNPJ.py
@@ -28,6 +28,11 @@ class TestCnpj(unittest.TestCase):
         masked_cnpj = self.cnpj.mask('11222333444455')
         self.assertEqual(masked_cnpj, '11.222.333/4444-55')
 
+    def test_mask_on_already_masked_cnpj(self):
+        """Verifica se o método mask funciona corretamente."""
+        masked_cnpj = self.cnpj.mask('11.222.333/4444-55')
+        self.assertEqual(masked_cnpj, '11.222.333/4444-55')
+
     def test_special_case(self):
         """Verifica os casos especiais de CNPJ."""
         cases = [

--- a/validate_docbr/CNPJ.py
+++ b/validate_docbr/CNPJ.py
@@ -40,6 +40,10 @@ class CNPJ(BaseDoc):
 
     def mask(self, doc: str = '') -> str:
         """Coloca a máscara de CNPJ na variável doc."""
+        if not self._validate_input(doc, ['.', '/', '-']):
+            # Documento previamente formatado
+            return doc
+        
         return f"{doc[:2]}.{doc[2:5]}.{doc[5:8]}/{doc[8:12]}-{doc[-2:]}"
 
     def _generate_first_digit(self, doc: Union[str, list]) -> str:


### PR DESCRIPTION
Caso você envie um CNPJ já formatado para o CNPJ().mask(), ele retorna um CNPJ totalmente errôneo. Este PR visa resolver isso colocando uma checagem anterior a formatação.