### PR TITLE
Conserta o workflow `lint`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: alvarofpp/linter:latest
+      volumes:
+        - ./:/app
     steps:
       - uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-> :warning: Estamos planejando a versão `2.0.0` do pacote. **Para saber as mudanças que estão por vir, leia a [issue #67](https://github.com/alvarofpp/validate-docbr/issues/67)**. Você também pode sugerir atualizações para o pacote na mesma issue, participe! :warning:
-
 # validate-docbr
 
 <a href="https://pypi.org/project/validate-docbr/">
   <img src="https://img.shields.io/pypi/v/validate-docbr.svg" alt="latest release" />
 </a>
+
+> :warning: Estamos planejando a versão `2.0.0` do pacote. **Para saber as mudanças que estão por
+> vir, leia a [issue #67](https://github.com/alvarofpp/validate-docbr/issues/67)**.
+> Você também pode sugerir atualizações para o pacote na mesma issue, participe! :warning:
 
 Pacote Python para validação de documentos brasileiros.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: '3.8'
-
 services:
   app:
     build:


### PR DESCRIPTION
O workflow `lint` não esta reconhecendo as configurações do arquivo `.lint/.markdownlintrc`. Além disso, eu atualizei o `README.md` diretamente pelo site do GitHub e não passou pelo workflow de `lint`, fazendo com que um erro fosse inserido na execucão do comando `lint-markdown`.