### PR TITLE
fix: Verifica tamanho de CPF (Resolve #74)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as fh:
 
 setuptools.setup(
     name="validate_docbr",
-    version="1.11.0",
+    version="1.11.1",
     author="Álvaro Ferreira Pires de Paiva",
     author_email="alvarofepipa@gmail.com",
     description="Validate brazilian documents.",

--- a/validate_docbr/CPF.py
+++ b/validate_docbr/CPF.py
@@ -18,6 +18,9 @@ class CPF(BaseDoc):
 
         doc = list(self._only_digits(doc))
 
+        if len(doc) > 11:
+            return False
+
         if len(doc) < 11:
             doc = self._complete_with_zeros(doc)
 


### PR DESCRIPTION
@jesusch relatou na issue #74 que tem casos em que o CNPJ consegue ser validado usando a classe `CPF`, o que não deveria ocorrer. Isso pode ser facilmente resolvido adicionando uma verificação de tamanho, pois o CNPJ é maior que o CPF em questão de quantidade de caracteres.